### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :shop_item, only: [:show, :destroy]
+  before_action :shop_item, only: [:show, :destroy, :edit, :update]
+  before_action :not_allowed_url, except: [:index, :show]
 
   def index 
     @items = Item.all.order("created_at DESC")
@@ -22,14 +23,16 @@ class ItemsController < ApplicationController
   def show
   end
 
-  #def edit
-  #end
-
-  #def update
-  #  if @item.save
-  #    redirect_to item_path
-  #  end
-  #end
+  def edit
+  end
+  #binding.pry
+  def update
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
   
   def destroy
     if current_user.id == @item.user_id
@@ -52,4 +55,9 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def not_allowed_url
+    if @item.user_id != current_user.id #|| @item.purchase !=nil
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :shop_item, only: [:show, :destroy, :edit, :update]
+  before_action :shop_item, only: [:show, :edit, :update, :destroy]
   before_action :not_allowed_url, except: [:index, :show]
 
   def index 
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
 
   def edit
   end
-  #binding.pry
+
   def update
     if @item.update(item_params)
       redirect_to item_path
@@ -47,7 +47,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.permit(:image, :name, :description, :category_id, :status_id, :prefecture_id, :shipping_fee_id, :shipping_day_id,
+    params.require(:item).permit(:image, :name, :description, :category_id, :status_id, :prefecture_id, :shipping_fee_id, :shipping_day_id,
                   :price).merge(user_id: current_user.id)
   end
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,3 +1,4 @@
+
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
 
@@ -8,8 +9,7 @@ app/assets/stylesheets/items/new.css %>
 
   <div class="items-sell-main"><%# /商品画像 %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%#= form_with model: @item, url: edit_item_path, local: true do |f| %>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
     <% render 'shared/error_messages', model: @item %>
 
     <div class="img-upload">
@@ -30,7 +30,7 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%#= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
@@ -128,8 +128,8 @@ app/assets/stylesheets/items/new.css %>
     </div>
 
     <div class="sell-btn-contents"><%# 下部ボタン %>
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
+      <%= link_to 'もどる', "#", class:"back-btn" %>
     </div>
   </div>
   <% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main"><%# /商品画像 %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
-    <% render 'shared/error_messages', model: @item %>
+    <%= render 'shared/error_messages', model: @item %>
 
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
   </header>
 
-  <div class="items-sell-main"><%# /商品画像 %>
+  <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
     <%= render 'shared/error_messages', model: @item %>
@@ -26,7 +26,7 @@ app/assets/stylesheets/items/new.css %>
     </div>
 
     <div class="new-items">
-      <div class="weight-bold-text"><%# 商品名と商品説明 %>
+      <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
@@ -80,7 +80,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
 
-    <div class="sell-price"><%# 販売価格 %>
+    <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
         <a class="question" href="#">?</a>
@@ -109,7 +109,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
 
-    <div class="caution"><%# 注意書き %>
+    <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
         <a href="#">行為</a>
@@ -127,7 +127,7 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
 
-    <div class="sell-btn-contents"><%# 下部ボタン %>
+    <div class="sell-btn-contents">
       <%= f.submit "変更する", class:"sell-btn" %>
       <%= link_to 'もどる', "#", class:"back-btn" %>
     </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -16,7 +16,6 @@
     </div>
   </div>
 
-  <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
       FURIMAが選ばれる3つの理由
@@ -57,10 +56,8 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
-  <div class='ad-contents'>
+  <div class='ad-contents'> <%# 画面中央の「会員数日本一位」帯部分 %>
     <h2 class='ad-title'>
       会員数日本一位
     </h2>
@@ -78,7 +75,6 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
   <div class='feature-contents'>
     <h2 class='title'>
@@ -115,27 +111,23 @@
     </ul>
   </div>
 
-  <div class='item-contents'> <%# 商品一覧 %>
+  <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
       新規投稿商品
     </div>
     <ul class='item-lists'>
       <% if @items.present? %>  
-      <% @items.each do |item| %>  
+      <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
-           <%# if item.purchase.present? %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
+           <%# if item.purchase.present? %> <%# TODO//ready: 商品が売れていればsold outを表示%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,10 +126,10 @@
       <li class='list'>
         <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %> 
+          <%= image_tag item.image, class: "item-img" %>
+           <%# if item.purchase.present? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <%#Rail if @item.order %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,8 +6,8 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with mdoel: @item, url: items_path, local: true do |f| %>    
-    <%= render 'shared/error_messages', model: @item %> <%# model: f.object(f.objectをmodelに渡す)とは、form_withで渡しているrender先のファイル(ここではエラーメッセージ)の"model"の情報を取ってくるメソッド %>       
-    <div class="img-upload"> <%# 商品について %>
+    <%= render 'shared/error_messages', model: @item %> <%# model: f.object(f.objectをmodelに渡す)とは、form_withで渡しているrender先のファイル(ここではエラーメッセージ)の"model"の情報を取ってくるメソッド %>
+    <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
         <span class="indispensable">必須</span>
@@ -51,7 +51,7 @@
       </div>
     </div>
     
-    <div class="items-detail"> <%# 配送について %>
+    <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
         <a class="question" href="#">?</a> 
@@ -75,7 +75,7 @@
       </div>
     </div>
 
-    <div class="sell-price"> <%# 販売価格 %>
+    <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
         <a class="question" href="#">?</a> 
@@ -104,7 +104,7 @@
       </div>
     </div>
 
-    <div class="caution"> <%# 注意書き %> 
+    <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
         <a href="#">行為</a>
@@ -122,7 +122,7 @@
       </p>
     </div>
 
-    <div class="sell-btn-contents"><%# 下部ボタン %>
+    <div class="sell-btn-contents">
       <%= f.submit "出品する",class:"sell-btn" %>
       <%=link_to "もどる", root_path, class:"back-btn" %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
       <%#= image_tag @item.image.variant(resize: '630x500'), class:"item-box-img" if @item.image.attached? %>
       <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# if @item.order %>
+      <%# if @item.purchase.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
@@ -28,14 +28,14 @@
     </div>
 
     <% if user_signed_in? %>
+    <%# if user_signed_in? && !@item.purchase.present? %>
     <% if current_user.id == @item.user_id %> 
-    <%#= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%#= link_to "購入画面に進む", item_path(@item.id) ,class:"item-red-btn"%>
+    <%#= link_to "購入画面に進む", item_purchases_path(@item.id) ,class:"item-red-btn"%>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
@@ -75,7 +75,7 @@
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り</span>
+        <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
         <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,22 +1,18 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
-<div class="item-show">
+<div class="item-show"> <%# 商品の概要 %>
   <div class="item-box">
     <h2 class="name">
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%#= image_tag @item.image.variant(resize: '630x500'), class:"item-box-img" if @item.image.attached? %>
+      <%#= image_tag @item.image.variant(resize: '630x500'), class:"item-box-img" if @item.image.attached? %> <%# TODO//ready: imageの有無の記述 %>
       <%= image_tag @item.image, class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# if @item.purchase.present? %>
+      <%# if @item.purchase.present? %><%# TODO//ready: 商品が売れている場合は、sold outを表示する記述 %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -28,16 +24,14 @@
     </div>
 
     <% if user_signed_in? %>
-    <%# if user_signed_in? && !@item.purchase.present? %>
+    <%# if user_signed_in? && !@item.purchase.present? %> <%# TODO//ready: when user signed in and 商品が売れていない場合の記述 %>
     <% if current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%#= link_to "購入画面に進む", item_purchases_path(@item.id) ,class:"item-red-btn"%>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%#= link_to "購入画面に進む", item_purchases_path(@item.id) ,class:"item-red-btn"%> <%# TODO//ready: 商品が売れていない場合の記述 %>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%> 
     <% end %>
     <% end %>
 
@@ -75,7 +69,7 @@
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
+        <span>お気に入り</span>
       </div>
       <div class="report-btn">
         <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
@@ -83,7 +77,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,8 @@ Rails.application.routes.draw do
   root to: 'items#index'
   resources :items
 
+  #resources :items do
+  #  resources :purchases, only: [:index, :create]
+  #end
+
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Item, type: :model do
       it 'fill out item registration' do
         expect(@item).to be_valid
       end
+      it 'an image attached' do
+        expect(@item).to be_valid
+      end
     end
 
     context 'when item unregistration because blank' do
@@ -90,6 +93,6 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('User must exist')
       end
-    end
+    end 
   end
 end


### PR DESCRIPTION
いつも大変お世話になっております。
どうぞ、よろしくお願いいたします。

#What: 商品情報編集機能を実装いたしました
#Why: 商品情報を編集するため


- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/efafcd35b3594dfdc710fca3769d2016

- 正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/386444f8498b24c3742612f8156832f5

- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/b782fff20f0d915b5de538ab36ff96d6

- 何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/ba351c2cb35127f4a2f8078413ef8bd8

- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/78ef1202c634f695e6c7edd07fa9248a

- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/8ed108a5fb759d208af419da11fa72aa

- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/9050f23ff326a18499a155fab1d9ca26

未実装：
- ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）

